### PR TITLE
update spatial_detection_scores to use bin_size instead of n_bins for…

### DIFF
--- a/spatial_compare/utils.py
+++ b/spatial_compare/utils.py
@@ -123,8 +123,12 @@ def spatial_detection_scores(
         )
 
     # determine number of bins on each axis for grouping the data spatially
-    nx_bins = np.ceil((s2.x_centroid.max() - s2.x_centroid.min()) / bin_size).astype(int)
-    ny_bins = np.ceil((s2.y_centroid.max() - s2.y_centroid.min()) / bin_size).astype(int)
+    nx_bins = np.ceil((s2.x_centroid.max() - s2.x_centroid.min()) / bin_size).astype(
+        int
+    )
+    ny_bins = np.ceil((s2.y_centroid.max() - s2.y_centroid.min()) / bin_size).astype(
+        int
+    )
 
     s2["xy_bucket"] = list(
         zip(


### PR DESCRIPTION
I didn't replace n_bins with bin_size in the notebooks (spatial_compare_examples.ipynb, dataset_testing.ipynb) so this will cause an error.
I think it is better to clear all the outputs in the jupyter notebooks prior to uploading to repository or else there are a lot of "non code" for git to follow. This could also be addressed in a different PR.