### PR TITLE
add outlier detection with RANSAC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.9"
 
 [project]
 name = "spatial_compare"
-version = "0.1"
+version = "0.3.0"
 description = "A package for comparing spatial transcriptomics datasets"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setuptools.setup(
         "kaleido",
     ],
     include_package_data=True,
-    version="0.2",
+    version="0.3.0",
     python_requires=">=3.9",
 )


### PR DESCRIPTION
Added outlier detection in the log-log space of gene expression in each cell type. 

The `spatial_compare_examples.ipynb` notebook now also includes manual modification of gene expression in 2 genes to show outlier detection at work:
<img width="860" height="922" alt="image" src="https://github.com/user-attachments/assets/5bb4382e-7604-4819-adbb-54d37f468b91" />
 `ACHE` and `PTMA` were both scaled before `run_and_plot()`, and in this cell group, they are both detected as the only outliers. In other cases, RANSAC identifies different sets of genes depending on expression level and overall fit. 

Closes #30 